### PR TITLE
Fix plain text highlighting in JSX

### DIFF
--- a/styles/languages/javascript.less
+++ b/styles/languages/javascript.less
@@ -34,14 +34,14 @@ Facebook
   .syntax--variable.syntax--other.syntax--class {
     color: @syntax-color-class;
   }
-  
+
   .syntax--punctuation.syntax--section.syntax--class {
     &.syntax--begin,
     &.syntax--end {
       color: @syntax-color-punctuation;
     }
   }
-  
+
   .syntax--meta.syntax--class.syntax--body {
     .syntax--meta.syntax--tag {
       color: @syntax-text-color;

--- a/styles/languages/javascript.less
+++ b/styles/languages/javascript.less
@@ -34,4 +34,17 @@ Facebook
   .syntax--variable.syntax--other.syntax--class {
     color: @syntax-color-class;
   }
+  
+  .syntax--punctuation.syntax--section.syntax--class {
+    &.syntax--begin,
+    &.syntax--end {
+      color: @syntax-color-punctuation;
+    }
+  }
+  
+  .syntax--meta.syntax--class.syntax--body {
+    .syntax--meta.syntax--tag {
+      color: @syntax-text-color;
+    }
+  }
 }


### PR DESCRIPTION
> **Bound to** #50

This PR fixes the color of plain text (body text) placed inside JSX tags.


<p align="center">Before<br><img src="https://user-images.githubusercontent.com/7836623/27985204-5b5f7c30-63e7-11e7-9e50-b16915de2781.png"/><br>After<br><img src="https://user-images.githubusercontent.com/7836623/27985206-6894cb12-63e7-11e7-857b-98f727a1df50.png"/></p>